### PR TITLE
fix warnings

### DIFF
--- a/src/atom/moov.rs
+++ b/src/atom/moov.rs
@@ -23,7 +23,6 @@ pub fn parse<R: Read + Seek>(r: &mut R) -> Option<MoovAtom> {
     if let Ok(value) = r.read_u32::<BigEndian>() {
         // atom_type should be "moov"
         if value != 0x6d6f6f76 {
-            panic!("moov atom not found at 0x{:x}", atom_offset);
             return None;
         }
     } else {

--- a/src/qtfile/mod.rs
+++ b/src/qtfile/mod.rs
@@ -63,7 +63,7 @@ pub fn parse_qtfile(file_name: &str) -> Result<QtFile, Box<dyn error::Error>> {
 
 impl fmt::Display for QtFileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str((self as &dyn error::Error).description())
+        f.write_str(&(self as &dyn error::Error).to_string())
     }
 }
 


### PR DESCRIPTION
fix the following warnings:

```
warning: unreachable statement
  --> src\atom\moov.rs:27:13
   |
26 |             panic!("moov atom not found at 0x{:x}", atom_offset);
   |             ----------------------------------------------------- any code following this expression is unreachable
27 |             return None;
   |             ^^^^^^^^^^^^ unreachable statement
   |
   = note: `#[warn(unreachable_code)]` on by default
   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more
 info)

warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
  --> src\qtfile\mod.rs:66:49
   |
66 |         f.write_str((self as &dyn error::Error).description())
   |                                                 ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```